### PR TITLE
added exec command at end of ENTRYPOINT Dockerfile.autosfx-entrypoint

### DIFF
--- a/docker/autosfx/load_everything.sh
+++ b/docker/autosfx/load_everything.sh
@@ -16,4 +16,6 @@ export PSOCAKE_FACILITY=LCLS
 # ccp4
 source /img/ccp4-7.1/bin/ccp4.setup-sh
 
+echo "sound check, one two one two"
 
+exec "$@"


### PR DESCRIPTION
needed `exec "$@"` at the end of `load_everything.sh`
